### PR TITLE
feat: add env var for configuring atlantis.yaml

### DIFF
--- a/cmd/atlantis-drift-detection/main.go
+++ b/cmd/atlantis-drift-detection/main.go
@@ -17,15 +17,16 @@ import (
 	"github.com/joho/godotenv"
 
 	// Empty import allows pinning to version atlantis uses
+	"github.com/joeshaw/envdecode"
 	_ "github.com/nlopes/slack"
 	"go.uber.org/zap"
 )
-import "github.com/joeshaw/envdecode"
 
 type config struct {
 	Repo               string        `env:"REPO,required"`
 	AtlantisHostname   string        `env:"ATLANTIS_HOST,required"`
 	AtlantisToken      string        `env:"ATLANTIS_TOKEN,required"`
+	AtlantisConfigPath string        `env:"ATLANTIS_CONFIG_PATH,default=atlantis.yaml"`
 	DirectoryWhitelist []string      `env:"DIRECTORY_WHITELIST"`
 	SlackWebhookURL    string        `env:"SLACK_WEBHOOK_URL"`
 	SkipWorkspaceCheck bool          `env:"SKIP_WORKSPACE_CHECK"`
@@ -130,6 +131,7 @@ func main() {
 		DirectoryWhitelist: cfg.DirectoryWhitelist,
 		Logger:             logger.With(zap.String("drifter", "true")),
 		Repo:               cfg.Repo,
+		AtlantisConfigPath: cfg.AtlantisConfigPath,
 		AtlantisClient: &atlantis.Client{
 			AtlantisHostname: cfg.AtlantisHostname,
 			Token:            cfg.AtlantisToken,

--- a/example.env
+++ b/example.env
@@ -2,6 +2,8 @@
 ATLANTIS_HOST=https://atlantis.company.com
 # Your atlantis token
 ATLANTIS_TOKEN=PRIVATE_TOKEN
+# Path to atlantis.yaml file (relative to repo root, default: atlantis.yaml)
+ATLANTIS_CONFIG_PATH=atlantis.yaml
 # A plan that is ok
 PLAN_SUMMARY_OK='{"Repo": "company/terraform", "Ref": "master", "Type": "Github", "Dir": "environments/aws/env1", "Workspace": "account1"}'
 # A plan that you expect to have changes

--- a/internal/atlantis/config.go
+++ b/internal/atlantis/config.go
@@ -46,8 +46,8 @@ func ParseRepoConfig(body string) (*SimpleAtlantisConfig, error) {
 	return &ret, nil
 }
 
-func ParseRepoConfigFromDir(dir string) (*SimpleAtlantisConfig, error) {
-	filename := filepath.Join(dir, "atlantis.yaml")
+func ParseRepoConfigFromDir(dir, configPath string) (*SimpleAtlantisConfig, error) {
+	filename := filepath.Join(dir, configPath)
 	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("error reading config: %s", err)

--- a/internal/drifter/drifter.go
+++ b/internal/drifter/drifter.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/cresta/atlantis-drift-detection/internal/atlantis"
 	"github.com/cresta/atlantis-drift-detection/internal/atlantisgithub"
 	"github.com/cresta/atlantis-drift-detection/internal/notification"
@@ -13,13 +16,12 @@ import (
 	"github.com/cresta/gogithub"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	"os"
-	"time"
 )
 
 type Drifter struct {
 	Logger             *zap.Logger
 	Repo               string
+	AtlantisConfigPath string
 	Cloner             *gogit.Cloner
 	GithubClient       gogithub.GitHub
 	Terraform          *terraform.Client
@@ -43,7 +45,7 @@ func (d *Drifter) Drift(ctx context.Context) error {
 			d.Logger.Warn("failed to cleanup repo", zap.Error(err))
 		}
 	}()
-	cfg, err := atlantis.ParseRepoConfigFromDir(repo.Location())
+	cfg, err := atlantis.ParseRepoConfigFromDir(repo.Location(), d.AtlantisConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to parse repo config: %w", err)
 	}


### PR DESCRIPTION
### Issues addressed

Memfault's atlantis.yaml is in `infra/terraform/atlantis.yaml` instead
of the repo root. This isn't configurable.

### Summary of changes

Add an env var for it.

### Test Plan

Works when running locally!

```
$ docker build . -t atlantis-drift-detection && docker run -it --rm --env-file .env atlantis-drift-detection
```