### PR TITLE
feat: Use a better slack message for Memfault repos

### DIFF
--- a/internal/notification/memfault.go
+++ b/internal/notification/memfault.go
@@ -1,0 +1,70 @@
+package notification
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// MemfaultSlackFormatter formats Slack messages specifically for Memfault's workflow
+type MemfaultSlackFormatter struct{}
+
+// NewMemfaultSlackFormatter creates a new instance of MemfaultSlackFormatter
+func NewMemfaultSlackFormatter() *MemfaultSlackFormatter {
+	return &MemfaultSlackFormatter{}
+}
+
+// FormatPlanDriftMessage formats a plan drift message for Slack with Memfault-specific command
+func (m *MemfaultSlackFormatter) FormatPlanDriftMessage(dir string) (string, error) {
+	// Extract the environment from the path (e.g., "eu" -> "eu", "staging" -> "staging", "production" -> "prod")
+	environment, err := m.extractEnvironment(dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to format plan drift message: %w", err)
+	}
+
+	// Build the profile name from the environment
+	profile := m.buildProfile(environment)
+
+	// Extract the project name from the last part of the directory
+	project := m.extractProject(dir)
+
+	message := fmt.Sprintf("Terraform drift detected in `%s`.\n", dir)
+	message += "Fix locally with this command:\n\n"
+	message += fmt.Sprintf("```\naws-vault exec %s -- inv terraform.apply -p %s\n```", profile, project)
+
+	return message, nil
+}
+
+// extractEnvironment extracts the environment from the directory path
+// Example: "infra/terraform/database/prod/eu-central-1/eu/lavinmq" -> "eu"
+// Example: "infra/terraform/database/staging/lavinmq" -> "staging"
+// Example: "infra/terraform/database/production/lavinmq" -> "production"
+func (m *MemfaultSlackFormatter) extractEnvironment(dir string) (string, error) {
+	parts := strings.Split(dir, "/")
+
+	// Look for the environment part (second to last part)
+	if len(parts) >= 2 {
+		environment := parts[len(parts)-2]
+		return environment, nil
+	}
+
+	// Error if we can't extract the environment
+	return "", fmt.Errorf("cannot extract environment from directory path: %s (need at least 2 path components)", dir)
+}
+
+// buildProfile builds the profile name from the environment
+// Example: "eu" -> "memfault-eu", "staging" -> "memfault-staging", "production" -> "memfault-prod"
+func (m *MemfaultSlackFormatter) buildProfile(environment string) string {
+	// Special case for production
+	if environment == "production" {
+		return "memfault-prod"
+	}
+
+	return "memfault-" + environment
+}
+
+// extractProject extracts the project name from the last part of the directory
+// Example: "infra/terraform/database/prod/eu-central-1/eu/lavinmq" -> "lavinmq"
+func (m *MemfaultSlackFormatter) extractProject(dir string) string {
+	return filepath.Base(dir)
+}

--- a/internal/notification/memfault_test.go
+++ b/internal/notification/memfault_test.go
@@ -1,0 +1,175 @@
+package notification
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMemfaultSlackFormatter_FormatPlanDriftMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		dir         string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "eu environment with lavinmq project",
+			dir:         "infra/terraform/database/prod/eu-central-1/eu/lavinmq",
+			expected:    "Terraform drift detected in `infra/terraform/database/prod/eu-central-1/eu/lavinmq`.\nFix locally with this command:\n\n```\naws-vault exec memfault-eu -- inv terraform.apply -p lavinmq\n```",
+			expectError: false,
+		},
+		{
+			name:        "staging environment with different project",
+			dir:         "infra/terraform/database/staging/myproject",
+			expected:    "Terraform drift detected in `infra/terraform/database/staging/myproject`.\nFix locally with this command:\n\n```\naws-vault exec memfault-staging -- inv terraform.apply -p myproject\n```",
+			expectError: false,
+		},
+		{
+			name:        "production environment with testapp project",
+			dir:         "terraform/infra/production/testapp",
+			expected:    "Terraform drift detected in `terraform/infra/production/testapp`.\nFix locally with this command:\n\n```\naws-vault exec memfault-prod -- inv terraform.apply -p testapp\n```",
+			expectError: false,
+		},
+		{
+			name:        "simple path structure",
+			dir:         "infra/terraform/simple/project",
+			expected:    "Terraform drift detected in `infra/terraform/simple/project`.\nFix locally with this command:\n\n```\naws-vault exec memfault-eu -- inv terraform.apply -p project\n```",
+			expectError: false,
+		},
+		{
+			name:        "invalid path - only one component",
+			dir:         "lavinmq",
+			expected:    "",
+			expectError: true,
+		},
+	}
+
+	formatter := NewMemfaultSlackFormatter()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := formatter.FormatPlanDriftMessage(tt.dir)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("FormatPlanDriftMessage() = %v, want %v", result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestMemfaultSlackFormatter_ExtractEnvironment(t *testing.T) {
+	tests := []struct {
+		name        string
+		dir         string
+		expected    string
+		expectError bool
+	}{
+		{"eu environment", "infra/terraform/database/prod/eu-central-1/eu/lavinmq", "eu", false},
+		{"staging environment", "infra/terraform/database/staging/myproject", "staging", false},
+		{"production environment", "terraform/infra/production/testapp", "production", false},
+		{"simple path", "infra/terraform/simple/project", "simple", false}, // second to last part
+		{"invalid path - only one component", "lavinmq", "", true},
+	}
+
+	formatter := NewMemfaultSlackFormatter()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := formatter.extractEnvironment(tt.dir)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("extractEnvironment() = %v, want %v", result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestMemfaultSlackFormatter_BuildProfile(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment string
+		expected    string
+	}{
+		{"eu environment", "eu", "memfault-eu"},
+		{"staging environment", "staging", "memfault-staging"},
+		{"production environment", "production", "memfault-prod"},
+	}
+
+	formatter := NewMemfaultSlackFormatter()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatter.buildProfile(tt.environment)
+			if result != tt.expected {
+				t.Errorf("buildProfile() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMemfaultSlackFormatter_ExtractProject(t *testing.T) {
+	tests := []struct {
+		name     string
+		dir      string
+		expected string
+	}{
+		{"lavinmq", "infra/terraform/database/prod/eu-central-1/eu/lavinmq", "lavinmq"},
+		{"myproject", "infra/terraform/database/staging/myproject", "myproject"},
+		{"testapp", "terraform/infra/production/testapp", "testapp"},
+		{"simple", "infra/terraform/simple", "simple"},
+	}
+
+	formatter := NewMemfaultSlackFormatter()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatter.extractProject(tt.dir)
+			if result != tt.expected {
+				t.Errorf("extractProject() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMemfaultSlackFormatter_MessageStructure(t *testing.T) {
+	formatter := NewMemfaultSlackFormatter()
+	dir := "infra/terraform/database/prod/eu-central-1/eu/lavinmq"
+
+	result, err := formatter.FormatPlanDriftMessage(dir)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Check that the message contains the expected components
+	if !strings.Contains(result, "Terraform drift detected in") {
+		t.Error("Message should contain 'Terraform drift detected in'")
+	}
+
+	if !strings.Contains(result, "Fix locally with this command:") {
+		t.Error("Message should contain 'Fix locally with this command:'")
+	}
+
+	if !strings.Contains(result, "aws-vault exec memfault-eu -- inv terraform.apply -p lavinmq") {
+		t.Error("Message should contain the correct aws-vault command")
+	}
+
+	if !strings.Contains(result, "`infra/terraform/database/prod/eu-central-1/eu/lavinmq`") {
+		t.Error("Message should contain the directory in backticks")
+	}
+}

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -2,13 +2,14 @@ package notification
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func genericNotificationTest(t *testing.T, notification Notification) {
 	ctx := context.Background()
 	require.NoError(t, notification.ExtraWorkspaceInRemote(ctx, "genericNotificationTest/ExtraWorkspaceInRemote", "test-workspace"))
 	require.NoError(t, notification.MissingWorkspaceInRemote(ctx, "genericNotificationTest/MissingWorkspaceInRemote", "test-workspace"))
-	require.NoError(t, notification.PlanDrift(ctx, "genericNotificationTest/PlanDrift", "test-workspace"))
+	require.NoError(t, notification.PlanDrift(ctx, "infra/terraform/database/prod/us-east-1/demo/lavinmq", "infra_terraform_database_prod_us-east-1_demo_lavinmq"))
 }

--- a/internal/notification/slackwebhook.go
+++ b/internal/notification/slackwebhook.go
@@ -63,7 +63,17 @@ func (s *SlackWebhook) MissingWorkspaceInRemote(ctx context.Context, dir string,
 }
 
 func (s *SlackWebhook) PlanDrift(ctx context.Context, dir string, workspace string) error {
-	return s.sendSlackMessage(ctx, fmt.Sprintf("Plan Drift workspace in remote\nDirectory: %s\nWorkspace: %s", dir, workspace))
+	// Comment out existing implementation
+	// return s.sendSlackMessage(ctx, fmt.Sprintf("Plan Drift workspace in remote\nDirectory: %s\nWorkspace: %s", dir, workspace))
+
+	// Use new memfault-specific formatter
+	formatter := NewMemfaultSlackFormatter()
+	message, err := formatter.FormatPlanDriftMessage(dir)
+	if err != nil {
+		fmt.Printf("failed to format plan drift message: %v\n", err)
+		return s.sendSlackMessage(ctx, fmt.Sprintf("Terraform Plan Drift\nDirectory: %s\nWorkspace: %s", dir, workspace))
+	}
+	return s.sendSlackMessage(ctx, message)
 }
 
 var _ Notification = &SlackWebhook{}


### PR DESCRIPTION
It would be nice to have a slack message that has a command that is
specific to Memfault's workflow. This PR updates the slack message to
include the command to run to resolve the drift.