### PR TITLE
fix: remove broken "missing workflow" check

### DIFF
--- a/internal/drifter/drifter.go
+++ b/internal/drifter/drifter.go
@@ -58,10 +58,11 @@ func (d *Drifter) Drift(ctx context.Context) error {
 	if err := d.FindDriftedWorkspaces(ctx, workspaces); err != nil {
 		return fmt.Errorf("failed to find drifted workspaces: %w", err)
 	}
-	d.Logger.Debug("Finding extra workspaces", zap.String("repo", d.Repo))
-	if err := d.FindExtraWorkspaces(ctx, workspaces); err != nil {
-		return fmt.Errorf("failed to find extra workspaces: %w", err)
-	}
+	// TOPHER: turned off check because it's causing errors
+	// d.Logger.Debug("Finding extra workspaces", zap.String("repo", d.Repo))
+	// if err := d.FindExtraWorkspaces(ctx, workspaces); err != nil {
+	// 	return fmt.Errorf("failed to find extra workspaces: %w", err)
+	// }
 	d.Logger.Info("Drift check complete", zap.String("repo", d.Repo))
 	return nil
 }


### PR DESCRIPTION
### Issues addressed
We're getting this error on Atlantis when running this check:

```
{"level":"panic","ts":1756932832.0765991,"caller":"atlantis-drift-detection/main.go:162","msg":"failed to drift","error":"failed to find extra workspaces: failed to init workspace infra/terraform/ecs-services/not-prod/us-east-1/staging/web-server: \nInitializing the backend...\nInitializing modules...\n- memfault-aws in ../../../../modules/web-server/aws\n- memfault-ecs-appautoscaling in ../../../../modules/common_appautoscaling\n- memfault-ecs-iam in ../../../../modules/common_iam\n:\nError: Invalid reference in variable validation\n\n  on ../../../../modules/common_appautoscaling/variables.tf line 41, in variable \"busy_time_autoscaling\":\n  41:       contains(keys(var.service_targets), service_name)\n\nThe condition for variable \"busy_time_autoscaling\" can only refer to the\nvariable itself, using var.busy_time_autoscaling.\n\n\nError: Invalid reference in variable validation\n\n  on ../../../../modules/common_appautoscaling/variables.tf line 64, in variable \"cpu_autoscaling\":\n  64:       contains(keys(var.service_targets), service_name)\n\nThe condition for variable \"cpu_autoscaling\" can only refer to the variable\nitself, using var.cpu_autoscaling.\n\n\nError: Invalid reference in variable validation\n\n  on ../../../../modules/web-server/aws/variables.tf line 89, in variable \"internal_statsd_address\":\n  89:     condition     = !(var.vector_internal_metrics_enabled && var.internal_statsd_address == \"\")\n\nThe condition for variable \"internal_statsd_address\" can only refer to the\nvariable itself, using var.internal_statsd_address.\n\n:exit status 1","stacktrace":"main.main\n\t/app/cmd/atlantis-drift-detection/main.go:162\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:283"}
```

### Summary of changes
Let's just remove it. I don't see the use.