### PR TITLE
fix: add timezone data

### DIFF
--- a/cmd/atlantis-drift-detection/main.go
+++ b/cmd/atlantis-drift-detection/main.go
@@ -18,6 +18,8 @@ import (
 	"github.com/robfig/cron/v3"
 
 	// Empty import allows pinning to version atlantis uses
+	_ "time/tzdata" // Embed timezone data for containerized environments
+
 	"github.com/joeshaw/envdecode"
 	_ "github.com/nlopes/slack"
 	"go.uber.org/zap"


### PR DESCRIPTION
Fixes this issue:

```
{"level":"error","ts":1757621191.8745272,"caller":"atlantis-drift-detection/main.go:167","msg":"Failed to load Eastern Time zone, using local time","error":"unknown time zone America/New_York","stacktrace":"main.main\n\t/app/cmd/atlantis-drift-detection/main.go:167\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:283"}
```