### PR TITLE
fix(drifter): pin plan ref to latest SHA, not "master"

### DIFF
--- a/cmd/atlantis-drift-detection/main.go
+++ b/cmd/atlantis-drift-detection/main.go
@@ -40,6 +40,7 @@ type config struct {
 	WorkflowRepo                string        `env:"WORKFLOW_REPO"`
 	WorkflowId                  string        `env:"WORKFLOW_ID"`
 	WorkflowRef                 string        `env:"WORKFLOW_REF"`
+	GitRef                      string        `env:"GIT_REF,default=master"`
 	RunOnceImmediatelyOnStartup bool          `env:"RUN_ONCE_IMMEDIATELY_ON_STARTUP"`
 }
 
@@ -147,6 +148,7 @@ func main() {
 		Logger:             logger.With(zap.String("drifter", "true")),
 		Repo:               cfg.Repo,
 		AtlantisConfigPath: cfg.AtlantisConfigPath,
+		GitRef:             cfg.GitRef,
 		AtlantisClient: &atlantis.Client{
 			AtlantisHostname: cfg.AtlantisHostname,
 			Token:            cfg.AtlantisToken,

--- a/internal/atlantis/client.go
+++ b/internal/atlantis/client.go
@@ -30,6 +30,10 @@ type PlanSummaryRequest struct {
 }
 
 type PlanResult struct {
+	// Ref is the git ref (typically a commit SHA) we asked Atlantis to plan
+	// against. Atlantis does not echo back the SHA it actually checked out,
+	// so this is the requested ref, not a confirmation.
+	Ref       string
 	Summaries []PlanSummary
 }
 
@@ -153,7 +157,7 @@ func (c *Client) PlanSummary(ctx context.Context, req *PlanSummaryRequest) (*Pla
 	if bodyResult.Failure != "" {
 		return nil, fmt.Errorf("failure making plan request: %s", bodyResult.Failure)
 	}
-	var ret PlanResult
+	ret := PlanResult{Ref: req.Ref}
 	for _, result := range bodyResult.ProjectResults {
 		if result.Failure != "" {
 			if strings.Contains(result.Failure, "This project is currently locked ") {

--- a/internal/atlantisgithub/atlantisgithub.go
+++ b/internal/atlantisgithub/atlantisgithub.go
@@ -2,7 +2,13 @@ package atlantisgithub
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/cresta/gogit"
 	"github.com/cresta/gogithub"
 )
@@ -19,4 +25,68 @@ func CheckOutTerraformRepo(ctx context.Context, gitHubClient gogithub.GitHub, cl
 		return nil, fmt.Errorf("failed to clone repo: %w", err)
 	}
 	return repository, nil
+}
+
+// GetLatestCommitSHA fetches the latest commit SHA for a given branch from GitHub API
+func GetLatestCommitSHA(ctx context.Context, gitHubClient gogithub.GitHub, repo string, branch string) (string, error) {
+	token, err := gitHubClient.GetAccessToken(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get access token: %w", err)
+	}
+
+	// Parse repo into owner and repo name
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid repo format, expected 'owner/repo', got: %s", repo)
+	}
+	owner := parts[0]
+	repoName := parts[1]
+
+	// Use GitHub REST API to get the latest commit SHA for the branch
+	// GET /repos/{owner}/{repo}/git/ref/{ref}
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/git/ref/heads/%s", owner, repoName, branch)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch branch ref: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("failed to fetch branch ref: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var refResponse struct {
+		Ref    string `json:"ref"`
+		NodeID string `json:"node_id"`
+		URL    string `json:"url"`
+		Object struct {
+			SHA  string `json:"sha"`
+			Type string `json:"type"`
+			URL  string `json:"url"`
+		} `json:"object"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&refResponse); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if refResponse.Object.SHA == "" {
+		return "", fmt.Errorf("no SHA found in response for branch %s", branch)
+	}
+
+	return refResponse.Object.SHA, nil
 }

--- a/internal/drifter/drifter.go
+++ b/internal/drifter/drifter.go
@@ -22,6 +22,7 @@ type Drifter struct {
 	Logger             *zap.Logger
 	Repo               string
 	AtlantisConfigPath string
+	GitRef             string
 	Cloner             *gogit.Cloner
 	GithubClient       gogithub.GitHub
 	Terraform          *terraform.Client
@@ -124,6 +125,21 @@ func (d *Drifter) drainAndExecute(ctx context.Context, toRun []errFunc) error {
 }
 
 func (d *Drifter) FindDriftedWorkspaces(ctx context.Context, ws atlantis.DirectoriesWithWorkspaces) error {
+	// Fetch the latest commit SHA for the configured git ref once at the start
+	gitRef := d.GitRef
+	if gitRef == "" {
+		gitRef = "master"
+	}
+	d.Logger.Info("Fetching latest commit SHA", zap.String("repo", d.Repo), zap.String("ref", gitRef))
+	latestSHA, err := atlantisgithub.GetLatestCommitSHA(ctx, d.GithubClient, d.Repo, gitRef)
+	if err != nil {
+		d.Logger.Warn("Failed to fetch latest commit SHA, falling back to branch name", zap.String("ref", gitRef), zap.Error(err))
+		// Fall back to using branch name if SHA fetch fails
+		latestSHA = gitRef
+	} else {
+		d.Logger.Info("Fetched latest commit SHA", zap.String("repo", d.Repo), zap.String("ref", gitRef), zap.String("sha", latestSHA))
+	}
+
 	runningFunc := func(dir string) errFunc {
 		return func(ctx context.Context) error {
 			if d.shouldSkipDirectory(dir) {
@@ -154,7 +170,7 @@ func (d *Drifter) FindDriftedWorkspaces(ctx context.Context, ws atlantis.Directo
 
 				pr, err := d.AtlantisClient.PlanSummary(ctx, &atlantis.PlanSummaryRequest{
 					Repo:      d.Repo,
-					Ref:       "master",
+					Ref:       latestSHA,
 					Type:      "Github",
 					Dir:       dir,
 					Workspace: workspace,
@@ -167,6 +183,13 @@ func (d *Drifter) FindDriftedWorkspaces(ctx context.Context, ws atlantis.Directo
 					}
 					return fmt.Errorf("failed to get plan summary for (%s#%s): %w", dir, workspace, err)
 				}
+				d.Logger.Info("Plan complete",
+					zap.String("dir", dir),
+					zap.String("workspace", workspace),
+					zap.String("requested_sha", pr.Ref),
+					zap.Bool("has_changes", pr.HasChanges()),
+					zap.Bool("is_locked", pr.IsLocked()),
+				)
 				if err := d.ResultCache.StoreDriftCheckResult(ctx, cacheKey, &processedcache.DriftCheckValue{
 					When:  time.Now(),
 					Error: "",


### PR DESCRIPTION
### Issues Addressed

The trigger is on our side. We send `Ref: "master"` to Atlantis's
`/api/plan` endpoint as a literal branch name. Atlantis maintains a
per-repo working-dir cache and, when given a branch name (not a SHA),
doesn't reliably refresh the clone before running the plan. The plan
ends up running against whatever SHA `master` happened to point at on
Atlantis the last time it cloned/fetched, not the current tip.

The Atlantis API response also doesn't echo back the SHA it actually
used, so we couldn't see this from our logs.

### Summary

Resolve `master` (or whatever `GIT_REF` is set to) to a concrete commit
SHA via the GitHub REST API once at the start of each drift run, then
send that SHA to Atlantis instead of the branch name. Falls back to
the branch name if the GitHub call fails.

### Test Plan

- [ ] Build and deploy to Coolify
- [ ] Confirm next daily run runs correctly

Resolves: PLAT-X