### PR TITLE
fix(drifter): revert pinning plan ref to a SHA

### DIFF
--- a/cmd/atlantis-drift-detection/main.go
+++ b/cmd/atlantis-drift-detection/main.go
@@ -40,7 +40,6 @@ type config struct {
 	WorkflowRepo                string        `env:"WORKFLOW_REPO"`
 	WorkflowId                  string        `env:"WORKFLOW_ID"`
 	WorkflowRef                 string        `env:"WORKFLOW_REF"`
-	GitRef                      string        `env:"GIT_REF,default=master"`
 	RunOnceImmediatelyOnStartup bool          `env:"RUN_ONCE_IMMEDIATELY_ON_STARTUP"`
 }
 
@@ -148,7 +147,6 @@ func main() {
 		Logger:             logger.With(zap.String("drifter", "true")),
 		Repo:               cfg.Repo,
 		AtlantisConfigPath: cfg.AtlantisConfigPath,
-		GitRef:             cfg.GitRef,
 		AtlantisClient: &atlantis.Client{
 			AtlantisHostname: cfg.AtlantisHostname,
 			Token:            cfg.AtlantisToken,

--- a/internal/atlantis/client.go
+++ b/internal/atlantis/client.go
@@ -30,10 +30,6 @@ type PlanSummaryRequest struct {
 }
 
 type PlanResult struct {
-	// Ref is the git ref (typically a commit SHA) we asked Atlantis to plan
-	// against. Atlantis does not echo back the SHA it actually checked out,
-	// so this is the requested ref, not a confirmation.
-	Ref       string
 	Summaries []PlanSummary
 }
 
@@ -157,7 +153,7 @@ func (c *Client) PlanSummary(ctx context.Context, req *PlanSummaryRequest) (*Pla
 	if bodyResult.Failure != "" {
 		return nil, fmt.Errorf("failure making plan request: %s", bodyResult.Failure)
 	}
-	ret := PlanResult{Ref: req.Ref}
+	var ret PlanResult
 	for _, result := range bodyResult.ProjectResults {
 		if result.Failure != "" {
 			if strings.Contains(result.Failure, "This project is currently locked ") {

--- a/internal/atlantisgithub/atlantisgithub.go
+++ b/internal/atlantisgithub/atlantisgithub.go
@@ -2,13 +2,7 @@ package atlantisgithub
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
-
 	"github.com/cresta/gogit"
 	"github.com/cresta/gogithub"
 )
@@ -25,68 +19,4 @@ func CheckOutTerraformRepo(ctx context.Context, gitHubClient gogithub.GitHub, cl
 		return nil, fmt.Errorf("failed to clone repo: %w", err)
 	}
 	return repository, nil
-}
-
-// GetLatestCommitSHA fetches the latest commit SHA for a given branch from GitHub API
-func GetLatestCommitSHA(ctx context.Context, gitHubClient gogithub.GitHub, repo string, branch string) (string, error) {
-	token, err := gitHubClient.GetAccessToken(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get access token: %w", err)
-	}
-
-	// Parse repo into owner and repo name
-	parts := strings.Split(repo, "/")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("invalid repo format, expected 'owner/repo', got: %s", repo)
-	}
-	owner := parts[0]
-	repoName := parts[1]
-
-	// Use GitHub REST API to get the latest commit SHA for the branch
-	// GET /repos/{owner}/{repo}/git/ref/{ref}
-	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/git/ref/heads/%s", owner, repoName, branch)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
-
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch branch ref: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("failed to fetch branch ref: status %d, body: %s", resp.StatusCode, string(body))
-	}
-
-	var refResponse struct {
-		Ref    string `json:"ref"`
-		NodeID string `json:"node_id"`
-		URL    string `json:"url"`
-		Object struct {
-			SHA  string `json:"sha"`
-			Type string `json:"type"`
-			URL  string `json:"url"`
-		} `json:"object"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&refResponse); err != nil {
-		return "", fmt.Errorf("failed to decode response: %w", err)
-	}
-
-	if refResponse.Object.SHA == "" {
-		return "", fmt.Errorf("no SHA found in response for branch %s", branch)
-	}
-
-	return refResponse.Object.SHA, nil
 }

--- a/internal/drifter/drifter.go
+++ b/internal/drifter/drifter.go
@@ -22,7 +22,6 @@ type Drifter struct {
 	Logger             *zap.Logger
 	Repo               string
 	AtlantisConfigPath string
-	GitRef             string
 	Cloner             *gogit.Cloner
 	GithubClient       gogithub.GitHub
 	Terraform          *terraform.Client
@@ -125,21 +124,6 @@ func (d *Drifter) drainAndExecute(ctx context.Context, toRun []errFunc) error {
 }
 
 func (d *Drifter) FindDriftedWorkspaces(ctx context.Context, ws atlantis.DirectoriesWithWorkspaces) error {
-	// Fetch the latest commit SHA for the configured git ref once at the start
-	gitRef := d.GitRef
-	if gitRef == "" {
-		gitRef = "master"
-	}
-	d.Logger.Info("Fetching latest commit SHA", zap.String("repo", d.Repo), zap.String("ref", gitRef))
-	latestSHA, err := atlantisgithub.GetLatestCommitSHA(ctx, d.GithubClient, d.Repo, gitRef)
-	if err != nil {
-		d.Logger.Warn("Failed to fetch latest commit SHA, falling back to branch name", zap.String("ref", gitRef), zap.Error(err))
-		// Fall back to using branch name if SHA fetch fails
-		latestSHA = gitRef
-	} else {
-		d.Logger.Info("Fetched latest commit SHA", zap.String("repo", d.Repo), zap.String("ref", gitRef), zap.String("sha", latestSHA))
-	}
-
 	runningFunc := func(dir string) errFunc {
 		return func(ctx context.Context) error {
 			if d.shouldSkipDirectory(dir) {
@@ -170,7 +154,7 @@ func (d *Drifter) FindDriftedWorkspaces(ctx context.Context, ws atlantis.Directo
 
 				pr, err := d.AtlantisClient.PlanSummary(ctx, &atlantis.PlanSummaryRequest{
 					Repo:      d.Repo,
-					Ref:       latestSHA,
+					Ref:       "master",
 					Type:      "Github",
 					Dir:       dir,
 					Workspace: workspace,
@@ -183,13 +167,6 @@ func (d *Drifter) FindDriftedWorkspaces(ctx context.Context, ws atlantis.Directo
 					}
 					return fmt.Errorf("failed to get plan summary for (%s#%s): %w", dir, workspace, err)
 				}
-				d.Logger.Info("Plan complete",
-					zap.String("dir", dir),
-					zap.String("workspace", workspace),
-					zap.String("requested_sha", pr.Ref),
-					zap.Bool("has_changes", pr.HasChanges()),
-					zap.Bool("is_locked", pr.IsLocked()),
-				)
 				if err := d.ResultCache.StoreDriftCheckResult(ctx, cacheKey, &processedcache.DriftCheckValue{
 					When:  time.Now(),
 					Error: "",


### PR DESCRIPTION
### Issues Addressed

#12 changed the plan request to send the latest commit SHA as `Ref`
instead of the branch name. After deploying I see every plan failing
in Coolify with:

```
fatal: Remote branch 2eeed97fc6190e15e2cfc5724c7c20667fd9ef37 not found in upstream origin
```

Atlantis's `/api/plan` flow maps `request.Ref` to `Pull.HeadBranch`,
then runs `git clone --depth=1 --branch <HeadBranch> --single-branch ...`.
`git clone --branch` only accepts branch or tag names; GitHub rejects
raw SHAs there, so the clone never even starts.

So #12's approach is structurally incompatible with Atlantis's API:
there's no way to pass a SHA via `Ref` and have the clone succeed.

### Summary

Revert #12. We're back to sending the branch name (default `master`)
as `Ref`, which restores Atlantis's ability to clone the repo.

The original "stale master" symptom that motivated #12 is still open;
I want to dig further (Atlantis lockfiles, working-dir state on the
container, possibly varying `request.PR` per run) before another
attempt.

### Test Plan

- [ ] Build and deploy to Coolify
- [ ] Confirm next drift run actually runs plans instead of 500ing

Resolves: PLAT-X